### PR TITLE
Make member avatars smaller

### DIFF
--- a/docs/members.md
+++ b/docs/members.md
@@ -4,7 +4,7 @@
 
 # [@ryota-ka](https://github.com/ryota-ka)
 
-![@ryota-ka](https://avatars.githubusercontent.com/u/7309170?s=256)
+![@ryota-ka](https://avatars.githubusercontent.com/u/7309170?s=96)
 
 リードエンジニア
 
@@ -14,7 +14,7 @@
 
 # [@hiroqn](https://github.com/hiroqn)
 
-![@hiroqn](https://avatars.githubusercontent.com/u/909385?s=256)
+![@hiroqn](https://avatars.githubusercontent.com/u/909385?s=96)
 
 リードエンジニア
 
@@ -24,7 +24,7 @@
 
 # [@azoson](https://github.com/azoson)
 
-![@azoson](https://avatars.githubusercontent.com/u/13480946?s=256)
+![@azoson](https://avatars.githubusercontent.com/u/13480946?s=96)
 
 東京大学工学部卒業、東京大学大学院学際情報学府中退。2017 年 4 月より HERP にエンジニアインターンとして参画し、約 1 年後正社員として入社。
 
@@ -32,7 +32,7 @@
 
 # [@mazamachi](https://github.com/mazamachi)
 
-![@mazamachi](https://avatars.githubusercontent.com/u/6847568?s=256)
+![@mazamachi](https://avatars.githubusercontent.com/u/6847568?s=96)
 
 東京大学工学部卒業、東京大学大学院工学系研究科中退。学生時代に株式会社はてな、Wantedly, Inc. 、Google Japan などでエンジニアインターンを経験。HERP には 2017 年 4 月より長期インターンののち、2017 年 12 月に新卒として入社。
 
@@ -40,7 +40,7 @@
 
 # [@b123400](https://github.com/b123400)
 
-![@b123400](https://avatars.githubusercontent.com/u/127193?s=256)
+![@b123400](https://avatars.githubusercontent.com/u/127193?s=96)
 
 香港中文大學卒業。旅をしながら iOS、Mac、ウェブ開発してた。Haskell に惹かれて 2018 年 2 月入社。
 
@@ -48,7 +48,7 @@
 
 # [@pf-siedler](https://github.com/pf-siedler)
 
-![@pf-siedler](https://avatars.githubusercontent.com/u/17399340?s=256)
+![@pf-siedler](https://avatars.githubusercontent.com/u/17399340?s=96)
 
 東京大学工学部卒業、東京大学大学院工学系研究科在籍。2018 年 9 月より同大学を休学し HERP にエンジニアインターンとして参画。 2019 年 2 月より正社員として入社。
 
@@ -56,7 +56,7 @@
 
 # [@CYBAI](https://github.com/CYBAI)
 
-![@CYBAI](https://avatars.githubusercontent.com/u/6782666?s=256)
+![@CYBAI](https://avatars.githubusercontent.com/u/6782666?s=96)
 
 元智大学卒業後、台灣樂天にてフロントエンドエンジニアとして 2 年勤務。その間業務外に Mozilla の Servo プロジェクトに参加。2019 年 2 月より正社員として入社。
 
@@ -64,7 +64,7 @@
 
 # [@Nymphium](https://github.com/Nymphium)
 
-![@Nymphium](https://avatars.githubusercontent.com/u/5901180?s=256)
+![@Nymphium](https://avatars.githubusercontent.com/u/5901180?s=96)
 
 プログラミングよりもプログラム言語それ自体が好きなタイプの人間｡
 言語設計､処理系､プログラム変換､型システム､継続に思いを馳せている｡
@@ -79,6 +79,6 @@
 
 # [@shin-sakata](https://github.com/shin-sakata)
 
-![@shin-sakata](https://avatars.githubusercontent.com/u/56592600?s=256)
+![@shin-sakata](https://avatars.githubusercontent.com/u/56592600?s=96)
 
 TODO


### PR DESCRIPTION
メンバの画像が文章に対してデカすぎた (本当は画像よりも紹介文その他の方をユーザに伝えるべき) ので小さく (256px^2 -> 96px^2) しました．

before | after
-- | --
![](https://gyazo.com/fa1dead03325918a6de2e8ebc52aad63.png) | ![](https://gyazo.com/d749021ee7841c693f6e1740ad42a678.png)