### PR TITLE
Add LICENSE file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,1 @@
+Copyright (c) 2020 HERP, Inc.


### PR DESCRIPTION
ライセンスを明記するファイルを追加した．
明示的にライセンスを指定しない場合，日本国の著作権法が適用されるとの認識だが，著作権者を明確にする目的で追加した．

@NaoyaMotoki 知財の単位がギリギリ良だったということで reviewer に assign しました．