### PR TITLE
Add "welfare" section to the company page

### DIFF
--- a/docs/company.md
+++ b/docs/company.md
@@ -9,6 +9,7 @@
   - [development team](#development-team)
   - [revenue team](#revenue-team)
   - [corporate team](#corporate-team)
+- [福利厚生](#福利厚生)
 
 ---
 
@@ -83,3 +84,10 @@
 - 法務
 - 総務
 - ファイナンス
+
+## 福利厚生
+
+- 社用端末支給
+- ディスプレイ支給
+- 書籍購入制度
+- フリードリンク (水・スペシャルティコーヒー)


### PR DESCRIPTION
福利厚生をどこに書こうか悩みましたが，新しくページを作るほどではないのと，全メンバに共通の内容なので，"HERPについて"のページに記載することにしました．
将来的に workstyle みたいなページを作る際に移すといいかもしれないです (そのようなページを作るかどうかはわからないが)