### PR TITLE
WorkflowのTriggerにpull_requestを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
-on: push
+# https://docs.github.com/ja/free-pro-team@latest/actions/reference/events-that-trigger-workflows#%E3%82%A4%E3%83%99%E3%83%B3%E3%83%88%E3%81%AE%E3%83%AA%E3%82%B9%E3%83%88%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B%E4%BE%8B
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`push` だと fork して pr 出す時に triggered されない
See #49 