### PR TITLE
Rename section name for our products

### DIFF
--- a/docs/company.md
+++ b/docs/company.md
@@ -3,7 +3,7 @@
 - [会社概要](#会社概要)
 - [ミッション](#ミッション)
 - [プロダクトビジョン](#プロダクトビジョン)
-- [サービス](#サービス)
+- [プロダクト](#プロダクト)
   - [HERP Hire](#herp-hire)
   - [HERP Nurture](#herp-nurture)
 - [チーム](#チーム)
@@ -56,7 +56,7 @@
 
 詳しくは [HERP Culture Deck](https://www.notion.so/herp/fcc88971ec924bb1b4ad77d36157bfcb) をご覧ください。
 
-## サービス
+## プロダクト
 
 ### [HERP Hire](https://herp.cloud/)
 


### PR DESCRIPTION
HERP Culture Deck を眺めていると，HERP Hire や HERP Nurture は「サービス」ではなく「プロダクト」と呼ばれているようなので，呼称を統一しました．

[Rendered](https://github.com/herp-inc/engineering-careers/blob/930c50cb08ff592d6b3a4dd61f022c714b353b8e/docs/company.md#%E3%83%97%E3%83%AD%E3%83%80%E3%82%AF%E3%83%88)