### PR TITLE
Add "industry" badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 株式会社 HERP エンジニア向け採用資料
 
-![We are hiring](https://img.shields.io/badge/status-hiring-brightgreen)
+![We are hiring](https://img.shields.io/badge/status-hiring-brightgreen) ![Industry: HRTech](https://img.shields.io/badge/industry-HRTech-orange)
 
 ## イントロダクション
 


### PR DESCRIPTION
HERP がどのようなビジネス領域でやっていっているのかを示すバッヂを README に置いた．

[rendered](https://github.com/herp-inc/engineering-careers/blob/ba3f41597191cab1af7be6c29a5741eeb47e0389/README.md)