### PR TITLE
Add "introduction" sentences to "technology stack" page

### DIFF
--- a/docs/technology-stack.md
+++ b/docs/technology-stack.md
@@ -1,5 +1,9 @@
 # 技術スタック
 
+HERP でどのような技術が用いられているかをご紹介します。
+
+開発チームのメンバーによるブログ記事をまとめた [HERP TechHub](https://tech-hub.herp.co.jp/) や、社内で用いられている技術に関して書かれた Scrapbox である [HERP TechNote](https://scrapbox.io/herp-technote/) も合わせてご覧ください。
+
 - [Web フロントエンド](#Web-フロントエンド)
 - [バックエンド](#バックエンド)
 - [DevOps / SRE](#DevOps--SRE)


### PR DESCRIPTION
「技術スタック」のページに，導入となる文章を足しました．

そもそも無愛想な箇条書きをやめたいと思っていて，その際に TechHub の各タグへのリンクを保持できるかが怪しいので，とりあえず先頭に TechHub への導線を確保しておきたかったという裏テーマもある．

[Rendered](https://github.com/herp-inc/engineering-careers/blob/67c3db34241a52ea7dc695fe3b5497e004f6c2b3/docs/technology-stack.md)
