### PR TITLE
Make "DevOps / SRE" section more descriptive

### DIFF
--- a/docs/technology-stack.md
+++ b/docs/technology-stack.md
@@ -38,12 +38,14 @@ HERP でどのような技術が用いられているかをご紹介します。
 
 ## DevOps / SRE
 
-- Amazon Web Services
-- Argo CD
-- Datadog
-- Istio
-- [Kubernetes](https://tech-hub.herp.co.jp/tags/kubernetes/1.html)
-- Terraform
+HERP ではクラウドプロバイダーとして [Amazon Web Services (AWS)](https://aws.amazon.com/) を採用し、[Amazon Elastic Kubernetes Service (EKS)](https://aws.amazon.com/eks/) によって構築された [Kubernetes](https://kubernetes.io/) クラスタを運用しています。
+また、クラスタ上では [Istio](https://istio.io/) を用いたサービスメッシュを構築しています。
+
+GitOps を用いた継続的デリバリを実現するため、上記のクラスタ上で [Argo CD](https://argoproj.github.io/cd/) を運用しています。
+
+AWS 上などに存在するリソースは [Terraform](https://www.terraform.io/) を用いてプロビジョニングを行っています。
+
+監視・ロギング・メトリクスには [Datadog](https://www.datadoghq.com/) を利用しています。
 
 ## その他
 


### PR DESCRIPTION
- [x] rebase after #126 is merged

---

「技術スタック」のページが，使っているツールの箇条書きになっており，採用モチベーションが伝わりづらかったので，各種ツールを採用している目的や，上段の思想も交えて記述できればよさそうだと考えている．
手始めに，"DevOps / SRE" セクションを，箇条書きから文章形式に書き換えた．

もし新しい採用技術や思想部分など書き足したくなった場合は別途適宜追記してください．

[Rendered](https://github.com/herp-inc/engineering-careers/blob/d8b1b6f12e995ae1eaffc2791460385365e5780f/docs/technology-stack.md#DevOps--SRE)