### PR TITLE
Add NixOS Foundation to sponsorship page

### DIFF
--- a/docs/sponsorship.md
+++ b/docs/sponsorship.md
@@ -8,6 +8,7 @@ HERP のビジネスは多数のオープンソースソフトウェア (OSS) �
 
 | 対象                                                                                                                       | 備考               |
 | -------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| [NixOS Foundation](https://nixos.org/community/#foundation)                                                                |                    |
 | [第 24 回プログラミングおよびプログラミング言語ワークショップ (PPL 2022)](https://jssst-ppl.org/workshop/2022/)            | ゴールドスポンサー |
 | [Haskell Foundation](https://haskell.foundation/)                                                                          | Functor level      |
 | [日本ソフトウェア科学会第 38 回大会 (JSSST 2021)](https://jssst2021.wordpress.com/)                                        | ブロンズスポンサー |


### PR DESCRIPTION
Nix 無しでは我々の開発は成り立たないので NixOS Foundation に寄付しました．
https://prtimes.jp/main/html/rd/p/000000046.000030340.html

[Rendered](https://github.com/herp-inc/engineering-careers/blob/040c4596b6c0e6938b8a1705ee66052415866a91/docs/sponsorship.md)